### PR TITLE
PIL-1421: Resolved flaky test in ObligationAndSubmissionsConnectorSpec

### DIFF
--- a/app/models/obligationsandsubmissions/ObligationsAndSubmissionsResponse.scala
+++ b/app/models/obligationsandsubmissions/ObligationsAndSubmissionsResponse.scala
@@ -18,14 +18,11 @@ package models.obligationsandsubmissions
 
 import play.api.libs.json.{Json, OFormat, Writes}
 
-import java.time.temporal.ChronoUnit
-import java.time.{LocalDate, ZoneOffset, ZonedDateTime}
+import java.time.{LocalDate, ZonedDateTime}
 
 sealed trait ObligationsAndSubmissionsResponse
 
 object ObligationsAndSubmissionsResponse {
-  val testZonedDateTime: ZonedDateTime = ZonedDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS)
-
   implicit val writes: Writes[ObligationsAndSubmissionsResponse] = Writes {
     case s: ObligationsAndSubmissionsSuccessResponse       => Json.obj("success" -> s.success)
     case e: ObligationsAndSubmissionsSimpleErrorResponse   => Json.obj("errors" -> e.error)

--- a/app/models/obligationsandsubmissions/ObligationsAndSubmissionsResponse.scala
+++ b/app/models/obligationsandsubmissions/ObligationsAndSubmissionsResponse.scala
@@ -24,7 +24,7 @@ import java.time.{LocalDate, ZoneOffset, ZonedDateTime}
 sealed trait ObligationsAndSubmissionsResponse
 
 object ObligationsAndSubmissionsResponse {
-  def now: ZonedDateTime = ZonedDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS)
+  val now: ZonedDateTime = ZonedDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS)
 
   implicit val writes: Writes[ObligationsAndSubmissionsResponse] = Writes {
     case s: ObligationsAndSubmissionsSuccessResponse       => Json.obj("success" -> s.success)

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,12 +2,12 @@ import sbt.*
 
 object AppDependencies {
 
-  private val bootstrapVersion = "9.6.0"
-  private val hmrcMongoVersion = "2.3.0"
+  private val bootstrapVersion = "9.11.0"
+  private val hmrcMongoVersion = "2.5.0"
 
   val compile: Seq[ModuleID] = Seq(
     play.sbt.PlayImport.ws,
-    "uk.gov.hmrc"           %% "play-frontend-hmrc-play-30" % "11.8.0",
+    "uk.gov.hmrc"           %% "play-frontend-hmrc-play-30" % "11.12.0",
     "uk.gov.hmrc"           %% "bootstrap-frontend-play-30" % bootstrapVersion,
     "uk.gov.hmrc.mongo"     %% "hmrc-mongo-play-30"         % hmrcMongoVersion,
     "org.typelevel"         %% "cats-core"                  % "2.13.0",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.24.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.5.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.6.0")
 
 addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.6")
 

--- a/test/helpers/TestDataFixture.scala
+++ b/test/helpers/TestDataFixture.scala
@@ -19,7 +19,6 @@ package helpers
 import models.btn.BTNStatus
 import models.obligationsandsubmissions.ObligationStatus.Fulfilled
 import models.obligationsandsubmissions.ObligationType.Pillar2TaxReturn
-import models.obligationsandsubmissions.ObligationsAndSubmissionsResponse.testZonedDateTime
 import models.obligationsandsubmissions.SubmissionType.UKTR
 import models.obligationsandsubmissions._
 import models.subscription._
@@ -31,9 +30,12 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryList
 import viewmodels.checkAnswers._
 import viewmodels.govuk.all.{FluentSummaryList, SummaryListViewModel}
 
-import java.time.{LocalDate, ZonedDateTime}
+import java.time.temporal.ChronoUnit
+import java.time.{LocalDate, ZoneOffset, ZonedDateTime}
 
 trait TestDataFixture extends SubscriptionLocalDataFixture {
+
+  lazy val testZonedDateTime: ZonedDateTime = ZonedDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS)
 
   lazy val obligationsAndSubmissionsSuccessResponseJson: JsValue = Json.toJson(obligationsAndSubmissionsSuccessResponse().success)
 


### PR DESCRIPTION
While this isn't directly related to PIL-1421 - it cropped up during this PR process for this ticket.

Failing test:
ObligationsAndSubmissionsSuccess(2025-03-10T14:49:10Z, List(AccountingPeriodDetails(2024-10-24, 2025-10-24, 2026-08-24, false, List(Obligation(Pillar2TaxReturn, Fulfilled, true, List(Submission(UKTR, 2025-03-10T14:49:10Z, None)))))))

was not equal to

ObligationsAndSubmissionsSuccess(2025-03-10T14:49:11Z, List(AccountingPeriodDetails(2024-10-24, 2025-10-24, 2026-08-24, false, List(Obligation(Pillar2TaxReturn, Fulfilled, true, List(Submission(UKTR, 2025-03-10T14:49:11Z, None))))))) 

The now function was being called twice in the test and occasionally the two ZonedDateTimes would be a second apart, causing a failing test. I've changed this function to be a val so that it remains fixed once evaluated and renamed it to testZonedDateTime.