### PR TITLE
PIL-1804: Added link from submission history page to due and overdue returns page

### DIFF
--- a/app/views/submissionhistory/SubmissionHistoryNoSubmissionsView.scala.html
+++ b/app/views/submissionhistory/SubmissionHistoryNoSubmissionsView.scala.html
@@ -42,8 +42,8 @@
     <br>
     @h2(messages("submissionHistoryNoSubmissions.h2"), size = "m")
     @if(isAgent) {
-    @paragraphMessageWithLink(Some(messages("submissionHistoryNoSubmissions.agent.p3")), linkMessage = messages("submissionHistoryNoSubmissions.link"), linkUrl = "#", linkFullStop = true)
+    @paragraphMessageWithLink(Some(messages("submissionHistoryNoSubmissions.agent.p3")), linkMessage = messages("submissionHistoryNoSubmissions.link"), linkUrl = controllers.dueandoverduereturns.routes.DueAndOverdueReturnsController.onPageLoad.url, linkFullStop = true)
     } else {
-    @paragraphMessageWithLink(Some(messages("submissionHistoryNoSubmissions.group.p3")), linkMessage = messages("submissionHistoryNoSubmissions.link"), linkUrl = "#", linkFullStop = true)
+    @paragraphMessageWithLink(Some(messages("submissionHistoryNoSubmissions.group.p3")), linkMessage = messages("submissionHistoryNoSubmissions.link"), linkUrl = controllers.dueandoverduereturns.routes.DueAndOverdueReturnsController.onPageLoad.url, linkFullStop = true)
     }
 }

--- a/app/views/submissionhistory/SubmissionHistoryView.scala.html
+++ b/app/views/submissionhistory/SubmissionHistoryView.scala.html
@@ -57,9 +57,9 @@
     <br>
     @h2(messages("submissionHistory.h2"), size = "m")
     @if(isAgent){
-    @paragraphMessageWithLink(Some(messages("submissionHistory.agent.p3")), linkMessage = messages("submissionHistory.link"), linkUrl = "#", linkFullStop = true)
+    @paragraphMessageWithLink(Some(messages("submissionHistory.agent.p3")), linkMessage = messages("submissionHistory.link"), linkUrl = controllers.dueandoverduereturns.routes.DueAndOverdueReturnsController.onPageLoad.url, linkFullStop = true)
     } else {
-    @paragraphMessageWithLink(Some(messages("submissionHistory.group.p3")), linkMessage = messages("submissionHistory.link"), linkUrl = "#", linkFullStop = true)
+    @paragraphMessageWithLink(Some(messages("submissionHistory.group.p3")), linkMessage = messages("submissionHistory.link"), linkUrl = controllers.dueandoverduereturns.routes.DueAndOverdueReturnsController.onPageLoad.url, linkFullStop = true)
     }
 
 }

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -313,14 +313,14 @@ dueAndOverdueReturns.obligationType.GlobeInformationReturn = Information return
 dueAndOverdueReturns.status.overdue = Overdue
 dueAndOverdueReturns.status.due = Due
 dueAndOverdueReturns.submissionHistory = Submission history
-dueAndOverdueReturns.submissionHistory.description1 = You can find full details of your group's submitted returns on the
+dueAndOverdueReturns.submissionHistory.description1 = You can find full details of your group’s submitted returns on the
 dueAndOverdueReturns.submissionHistory.link = submission history
 dueAndOverdueReturns.submissionHistory.description2 = page.
 
 dueAndOverdueReturns.agent.multipleReturns = If your client has multiple returns due, they will be separated by accounting periods.
-dueAndOverdueReturns.agent.commercialSoftware = You must submit each return before its due date using your clients commercial software supplier.
+dueAndOverdueReturns.agent.commercialSoftware = You must submit each return before its due date using your client’s commercial software supplier.
 dueAndOverdueReturns.agent.noReturns = Your client is up to date with their returns for this accounting period.
-dueAndOverdueReturns.agent.submissionHistory.description1 = You can find full details of your clients submitted returns on the               
+dueAndOverdueReturns.agent.submissionHistory.description1 = You can find full details of your client’s submitted returns on the
 
 ###############################################
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,9 +14,9 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.2.2")
 
 addSbtPlugin("io.github.irundaia" % "sbt-sassify" % "1.5.2")
 
-addSbtPlugin("net.ground5hark.sbt" % "sbt-concat" % "0.2.0")
+addSbtPlugin("com.github.sbt" % "sbt-concat" % "1.0.0")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
+addSbtPlugin("com.github.sbt" % "sbt-digest" % "2.0.0")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 

--- a/test/controllers/dueandoverduereturns/DueAndOverdueReturnsControllerSpec.scala
+++ b/test/controllers/dueandoverduereturns/DueAndOverdueReturnsControllerSpec.scala
@@ -125,7 +125,7 @@ class DueAndOverdueReturnsControllerSpec extends SpecBase with MockitoSugar with
 
         emptyContent must include("Your client is up to date with their returns for this accounting period")
         dueContent   must include("If your client has multiple returns due, they will be separated by accounting periods")
-        dueContent   must include("You must submit each return before its due date using your clients commercial software supplier")
+        dueContent   must include("You must submit each return before its due date using your client’s commercial software supplier")
       }
 
     }

--- a/test/views/dueandoverduereturns/DueAndOverdueReturnsViewSpec.scala
+++ b/test/views/dueandoverduereturns/DueAndOverdueReturnsViewSpec.scala
@@ -246,7 +246,7 @@ class DueAndOverdueReturnsViewSpec extends ViewSpecBase with DueAndOverdueReturn
         "show the correct multiple returns information for agents" in {
           val infoMessages = view.select("p.govuk-body")
           infoMessages.get(0).text mustEqual "If your client has multiple returns due, they will be separated by accounting periods."
-          infoMessages.get(1).text mustEqual "You must submit each return before its due date using your clients commercial software supplier."
+          infoMessages.get(1).text mustEqual "You must submit each return before its due date using your client’s commercial software supplier."
         }
       }
 
@@ -255,7 +255,7 @@ class DueAndOverdueReturnsViewSpec extends ViewSpecBase with DueAndOverdueReturn
 
         "show the agent-specific submission history description" in {
           val submissionHistoryParagraph = view.select("p.govuk-body").stream.filter(p => p.text.contains("submission history")).findFirst().get()
-          submissionHistoryParagraph.text must include("You can find full details of your clients submitted returns on the submission history page.")
+          submissionHistoryParagraph.text must include("You can find full details of your client’s submitted returns on the submission history page.")
         }
       }
     }

--- a/test/views/submissionhistory/SubmissionHistoryNoSubmissionsViewSpec.scala
+++ b/test/views/submissionhistory/SubmissionHistoryNoSubmissionsViewSpec.scala
@@ -60,8 +60,8 @@ class SubmissionHistoryNoSubmissionsViewSpec extends ViewSpecBase {
       organisationView.getElementsByTag("p").text must include(
         "Information on your group’s"
       )
-      link.text must include("due and overdue returns")
-      link.attr("href") mustEqual "#" //TODO: Change URL when due and overdue returns page is built
+      link.text         must include("due and overdue returns")
+      link.attr("href") must include("/due-and-overdue-returns")
     }
   }
 
@@ -84,8 +84,8 @@ class SubmissionHistoryNoSubmissionsViewSpec extends ViewSpecBase {
       agentView.getElementsByTag("p").text must include(
         "Information on your client’s"
       )
-      link.text must include("due and overdue returns")
-      link.attr("href") mustEqual "#" //TODO: Change URL when due and overdue returns page is built
+      link.text         must include("due and overdue returns")
+      link.attr("href") must include("/due-and-overdue-returns")
     }
   }
 }

--- a/test/views/submissionhistory/SubmissionHistoryViewSpec.scala
+++ b/test/views/submissionhistory/SubmissionHistoryViewSpec.scala
@@ -90,8 +90,8 @@ class SubmissionHistoryViewSpec extends ViewSpecBase with SubmissionHistoryDataF
       organisationView.getElementsByTag("p").text must include(
         "Information on your group’s"
       )
-      link.text must include("due and overdue returns")
-      link.attr("href") mustEqual "#" //TODO: Change URL when due and overdue returns page is built
+      link.text         must include("due and overdue returns")
+      link.attr("href") must include("/due-and-overdue-returns")
     }
   }
 
@@ -112,8 +112,8 @@ class SubmissionHistoryViewSpec extends ViewSpecBase with SubmissionHistoryDataF
       agentView.getElementsByTag("p").text must include(
         "Information on your client’s"
       )
-      link.text must include("due and overdue returns")
-      link.attr("href") mustEqual "#" //TODO: Change URL when due and overdue returns page is built
+      link.text         must include("due and overdue returns")
+      link.attr("href") must include("/due-and-overdue-returns")
     }
   }
 }


### PR DESCRIPTION
We need to add the URL into the link placeholder at the bottom of the submission history page (/submission-history) in the submission frontend. The submission history page and the due and overdue returns page were developed in tandem so this was unable to be implemented at the time. This should be a minimal change from the dev perspective but this will also impact the test automation scenarios.

This should link to the due and overdue returns page: /due-and-overdue-returns