### PR TITLE
PIL-1828|Capitalisation consistency for pillar 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Front-end microservice for Pillar 2  project. Pillar 2 refers to the Global Minimum Tax being introduced by the Organisation for Economic Cooperation and Development (OECD).
 
-The Pillar 2 Tax will ensure that global Multinational Enterprises (MNEs) with a turnover of >€750m are subject to a minimum Effective Tax Rate of 15%, i.e. a top-up tax for Medium to Large MNEs.
+The Pillar 2 Top-up Taxes will ensure that global Multinational Enterprises (MNEs) with a turnover of >€750m are subject to a minimum Effective Tax Rate of 15%, i.e. a top-up tax for Medium to Large MNEs.
 
 ## Running the service
 

--- a/app/models/obligationsandsubmissions/Submission.scala
+++ b/app/models/obligationsandsubmissions/Submission.scala
@@ -41,7 +41,7 @@ object SubmissionType extends Enum[SubmissionType] with PlayJsonEnum[SubmissionT
     override val fullName: String = "Overseas Return Notification"
   }
   case object BTN extends SubmissionType {
-    override val fullName: String = "Below Threshold Notification"
+    override val fullName: String = "Below-Threshold Notification"
   }
   case object GIR extends SubmissionType {
     override val fullName: String = "Information Return"

--- a/app/services/FopService.scala
+++ b/app/services/FopService.scala
@@ -38,8 +38,8 @@ class FopService @Inject() (
     foUserAgent.setAuthor("HMRC forms service")
     foUserAgent.setProducer("HMRC forms services")
     foUserAgent.setCreator("HMRC forms services")
-    foUserAgent.setSubject("Report Pillar 2 top-up taxes")
-    foUserAgent.setTitle("Report Pillar 2 top-up taxes")
+    foUserAgent.setSubject("Report Pillar 2 Top-up Taxes")
+    foUserAgent.setTitle("Report Pillar 2 Top-up Taxes")
   }
 
   def render(input: String): Future[Array[Byte]] = Future {

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -1,4 +1,4 @@
-service.name = Report Pillar 2 top-up taxes
+service.name = Report Pillar 2 Top-up Taxes
 
 site.back = Back
 site.remove = Remove
@@ -42,8 +42,8 @@ error.number = Please enter a valid number
 error.required = Please enter a value
 error.summary.title = There is a problem
 
-index.title = Welcome to Report Pillar 2 top-up taxes
-index.heading = Welcome to Report Pillar 2 top-up taxes
+index.title = Welcome to Report Pillar 2 Top-up Taxes
+index.heading = Welcome to Report Pillar 2 Top-up Taxes
 index.guidance = Welcome to your new frontend. Please see the README file for a guide to getting started.
 
 under_construction.heading = Under Construction
@@ -64,89 +64,89 @@ signedOut.guidance = We did not save your answers.
 unauthorised.title = You can’t access this service with this account
 unauthorised.heading = You can’t access this service with this account
 unauthorised.guidance = You need to {0} to access this page.
-unauthorised.guidance.link = register to report Pillar 2 top-up taxes
+unauthorised.guidance.link = register to report Pillar 2 Top-up Taxes
 
 unauthorised.individual.heading = Sorry, you’re unable to use this service
 unauthorised.individual.message = You’ve signed in with an individual account. Only users with an organisation account can register to use this service.
 unauthorised.individual.message2 = If the group still needs to register,
 unauthorised.individual.hyper1 = sign in to Government Gateway with an organisation account.
-unauthorised.individual.hyper2 = Find out more about who can report for Pillar 2 top-up taxes
+unauthorised.individual.hyper2 = Find out more about who can report for Pillar 2 Top-up Taxes
 
 unauthorised.org.standard.heading = Sorry, you’re unable to use this service
 unauthorised.org.standard.message = You’ve signed in with a standard organisation account.
 unauthorised.org.standard.message2 = Only Government Gateway accounts with an administrator role can register to use this service.
-unauthorised.org.standard.message3 = You need to find someone with an administrator’s Government Gateway user ID who can register and then give you authority to report and manage pillar 2 top-up taxes.
-unauthorised.org.standard.hyperlink = Find out more about who can report for Pillar 2 top-up taxes
+unauthorised.org.standard.message3 = You need to find someone with an administrator’s Government Gateway user ID who can register and then give you authority to report and manage Pillar 2 Top-up Taxes.
+unauthorised.org.standard.hyperlink = Find out more about who can report for Pillar 2 Top-up Taxes
 
 unauthorised.agent.heading = Sorry, you’re unable to use this service
 unauthorised.agent.message = You’ve signed in using an agent’s Government Gateway user ID. Only groups can register to use this service.
-unauthorised.agent.message2 = If you are an agent that has been given authorisation to report Pillar 2 top-up taxes on behalf of a group, you must
+unauthorised.agent.message2 = If you are an agent that has been given authorisation to report Pillar 2 Top-up Taxes on behalf of a group, you must
 unauthorised.agent.hyper1 = sign in via Agent Services.
-unauthorised.agent.message3 = If you need to request authorisation to report Pillar 2 top-up taxes, you must
+unauthorised.agent.message3 = If you need to request authorisation to report Pillar 2 Top-up Taxes, you must
 unauthorised.agent.hyper2 = request authorisation via Agent services.
-unauthorised.agent.hyper3 = Find out more about who can report for Pillar 2 top-up taxes
+unauthorised.agent.hyper3 = Find out more about who can report for Pillar 2 Top-up Taxes
 
 ###############################################
 #
 # Agent Services
 #
 ###############################################
-agent.pillar2Ref.title = What is your client’s Pillar 2 top-up taxes ID?
-agent.pillar2Ref.heading = What is your client’s Pillar 2 top-up taxes ID?
-agent.pillar2Ref.hint = This is 15 characters, for example, XMPLR0123456789. The current filing member can find it on their Pillar 2 taxes top-up homepage.
-agent.pillar2Ref.error.required = Enter your client’s Pillar 2 top-up taxes ID
-agent.pillar2Ref.error.format = Enter a Pillar 2 top-up taxes ID in the correct format, like XMPLR0123456789
-agent.pillar2Ref.error.length = Pillar 2 top-up taxes ID must be 15 characters
+agent.pillar2Ref.title = What is your client’s Pillar 2 Top-up Taxes ID?
+agent.pillar2Ref.heading = What is your client’s Pillar 2 Top-up Taxes ID?
+agent.pillar2Ref.hint = This is 15 characters, for example, XMPLR0123456789. The current filing member can find it on their Pillar 2 Top-up Taxes homepage.
+agent.pillar2Ref.error.required = Enter your client’s Pillar 2 Top-up Taxes ID
+agent.pillar2Ref.error.format = Enter a Pillar 2 Top-up Taxes ID in the correct format, like XMPLR0123456789
+agent.pillar2Ref.error.length = Pillar 2 Top-up Taxes ID must be 15 characters
 
 agent.clientConfirm.title = Confirm your client’s details
 agent.clientConfirm.heading = Confirm your client’s details
-agent.clientConfirm.h2.upe = Client’s ultimate parent
-agent.clientConfirm.h2.id = Client’s Pillar 2 top-up taxes ID
-agent.clientConfirm.link = Enter a different client’s Pillar 2 top-up taxes ID
+agent.clientConfirm.h2.upe = Client’s Ultimate Parent Entity
+agent.clientConfirm.h2.id = Client’s Pillar 2 Top-up Taxes ID
+agent.clientConfirm.link = Enter a different client’s Pillar 2 Top-up Taxes ID
 
 agent.noMatch.title = Your client’s details did not match HMRC records
 agent.noMatch.heading = Your client’s details did not match HMRC records
 agent.noMatch.p1 = We could not match the details you entered with records held by HMRC.
-agent.noMatch.link = Re-enter your client’s Pillar 2 top-up taxes ID to try again
+agent.noMatch.link = Re-enter your client’s Pillar 2 Top-up Taxes ID to try again
 
 agent.error.title = Sorry, there is a problem with the service
 agent.error.heading = Sorry, there is a problem with the service
 agent.error.p1 = Please try again later.
 agent.error.link = Return to your Agent Services Account
 
-agent.unauthorised.title = You have not been authorised to report this client’s Pillar 2 top-up taxes
-agent.unauthorised.heading = You have not been authorised to report this client’s Pillar 2 top-up taxes
+agent.unauthorised.title = You have not been authorised to report this client’s Pillar 2 Top-up Taxes
+agent.unauthorised.heading = You have not been authorised to report this client’s Pillar 2 Top-up Taxes
 agent.unauthorised.p1 = You need to
-agent.unauthorised.link = request authorisation to report and manage this client’s Pillar 2 top-up taxes
+agent.unauthorised.link = request authorisation to report and manage this client’s Pillar 2 Top-up Taxes
 
 agent.individual.title = Sorry, you’re unable to use this service
 agent.individual.heading = Sorry, you’re unable to use this service
 agent.individual.p1 = You’ve signed in with an individual account.
 agent.individual.p2 = Only users with an agent services account can use this service.
-agent.individual.bullet.p1 = if you are an agent that has been given authorisation to report Pillar 2 top-up taxes on behalf of a group, you must
+agent.individual.bullet.p1 = if you are an agent that has been given authorisation to report Pillar 2 Top-up Taxes on behalf of a group, you must
 agent.individual.bullet.p1.link = sign in via agent services
-agent.individual.bullet.p2 = if you need to request authorisation to report Pillar 2 top-up taxes, you must
+agent.individual.bullet.p2 = if you need to request authorisation to report Pillar 2 Top-up Taxes, you must
 agent.individual.bullet.p2.link = request authorisation on agent services
-agent.individual.link = Find out more about who can report for Pillar 2 top-up taxes
+agent.individual.link = Find out more about who can report for Pillar 2 Top-up Taxes
 
 agent.organisation.title = Sorry, you’re unable to use this service
 agent.organisation.heading = Sorry, you’re unable to use this service
 agent.organisation.p1 = You’ve signed in with an organisations account.
 agent.organisation.p2 = Only users with an agent services account can use this service.
-agent.organisation.bullet.p1 = if you are an agent that has been given authorisation to report Pillar 2 top-up taxes on behalf of a group, you must
+agent.organisation.bullet.p1 = if you are an agent that has been given authorisation to report Pillar 2 Top-up Taxes on behalf of a group, you must
 agent.organisation.bullet.p1.link = sign in via agent services
-agent.organisation.bullet.p2 = if you need to request authorisation to report Pillar 2 top-up taxes, you must
+agent.organisation.bullet.p2 = if you need to request authorisation to report Pillar 2 Top-up Taxes, you must
 agent.organisation.bullet.p2.link = request authorisation on agent services
-agent.organisation.link = Find out more about who can report for Pillar 2 top-up taxes
+agent.organisation.link = Find out more about who can report for Pillar 2 Top-up Taxes
 
-asa.agent.title = ASA Home page for Pillar 2 top-up taxes screen
-asa.agent.heading = ASA Home page for Pillar 2 top-up taxes screen
+asa.agent.title = ASA Home page for Pillar 2 Top-up Taxes screen
+asa.agent.heading = ASA Home page for Pillar 2 Top-up Taxes screen
 asa.agent.p1 = This screen is  home page in development and local for ASA, but  for QA, staging  and production, ASA has it own pages.
 ###############################################
 
 uktr.ukTaxReturnStart.title = UK Tax Return (UKTR)
 uktr.ukTaxReturnStart.header = UK Tax Return (UKTR)
-uktr.ukTaxReturnStart.p1 = A UKTR fulfills your obligation to submit Pillar 2 top-up taxes for your current accounting period. You can report both Domestic Top-up Tax and Multinational Top-up Tax liabilities.
+uktr.ukTaxReturnStart.p1 = A UKTR fulfills your obligation to submit Pillar 2 Top-up Taxes for your current accounting period. You can report both Domestic Top-up Tax and Multinational Top-up Tax liabilities.
 uktr.ukTaxReturnStart.p2 = If your group only has entities located in the UK, your return will include Domestic Top-up Tax.
 uktr.ukTaxReturnStart.p3 = If your group has entities located both inside and outside the UK, your return will include both Domestic Top-up Tax and Multinational Top-up Tax.
 uktr.ukTaxReturnStart.subheading = How to submit a UKTR
@@ -155,16 +155,16 @@ uktr.ukTaxReturnStart.p4.link = ensure your group’s details are updated
 uktr.ukTaxReturnStart.p5 = HMRC cannot recommend or endorse any one service over another and will not be responsible for any loss, damage, cost or expense in connection with using the software.
 uktr.ukTaxReturnStart.p6.link = Choose a supplier to submit your UKTR from this list
 uktr.ukTaxReturnStart.inactive.subheading = Important
-uktr.ukTaxReturnStart.inactive.p1 = Your account has a Below Threshold Notification (BTN) and is inactive. Submit a UK tax return (UKTR) to re-activate your account.
+uktr.ukTaxReturnStart.inactive.p1 = Your account has a Below-Threshold Notification (BTN) and is inactive. Submit a UK tax return (UKTR) to re-activate your account.
 
 ###############################################
 #
-# Below Threshold Notification
+# Below-Threshold Notification
 #
 ###############################################
 
-btn.beforeStart.title = Below Threshold Notification
-btn.beforeStart.header = Below Threshold Notification
+btn.beforeStart.title = Below-Threshold Notification
+btn.beforeStart.header = Below-Threshold Notification
 btn.beforeStart.p1 = A Below-Threshold Notification removes your group’s obligation to submit a UKTR for the current accounting period and all future ones.
 btn.beforeStart.header2 = Who can submit a Below-Threshold Notification
 btn.beforeStart.p2 = You can submit a Below-Threshold Notification if the group:
@@ -232,7 +232,7 @@ btn.submitUKTR.p2 = You can submit a nil return UK Tax Return if your group is n
 btn.submitUKTR.link = Find out more about submitting a late or new UK Tax Return
 
 btn.cya.heading = Check your answers to submit your Below-Threshold Notification
-btn.cya.p1 = Now submit your Below Threshold Notification
+btn.cya.p1 = Now submit your Below-Threshold Notification
 btn.cya.p2 = By submitting these details, you are confirming that the information is correct and complete to the best of your knowledge.
 
 btn.thresholdMet.title = Based on your answer, your group must submit a UK Tax Return

--- a/test/views/agent/AgentClientConfirmDetailsViewSpec.scala
+++ b/test/views/agent/AgentClientConfirmDetailsViewSpec.scala
@@ -41,8 +41,8 @@ class AgentClientConfirmDetailsViewSpec extends ViewSpecBase {
     }
 
     "have two h2 headings" in {
-      view.getElementsByTag("h2").text must include("Client’s ultimate parent")
-      view.getElementsByTag("h2").text must include("Client’s Pillar 2 top-up taxes ID")
+      view.getElementsByTag("h2").text must include("Client’s Ultimate Parent Entity")
+      view.getElementsByTag("h2").text must include("Client’s Pillar 2 Top-up Taxes ID")
     }
 
     "display the org name and pillar 2 id" in {
@@ -53,7 +53,7 @@ class AgentClientConfirmDetailsViewSpec extends ViewSpecBase {
     "have a link" in {
       val link = view.getElementsByClass("govuk-body").last().getElementsByTag("a")
       link.attr("href") must include(routes.AgentController.onSubmitClientPillarId.url)
-      link.text         must include("Enter a different client’s Pillar 2 top-up taxes ID")
+      link.text         must include("Enter a different client’s Pillar 2 Top-up Taxes ID")
     }
 
     "have a button" in {

--- a/test/views/agent/AgentClientNoMatchViewSpec.scala
+++ b/test/views/agent/AgentClientNoMatchViewSpec.scala
@@ -31,7 +31,7 @@ class AgentClientNoMatchViewSpec extends ViewSpecBase {
   "Agent Client No Match View" should {
 
     "have a title" in {
-      val title = "Your client’s details did not match HMRC records - Report Pillar 2 top-up taxes - GOV.UK"
+      val title = "Your client’s details did not match HMRC records - Report Pillar 2 Top-up Taxes - GOV.UK"
       view.getElementsByTag("title").first().text mustBe title
     }
 
@@ -46,7 +46,7 @@ class AgentClientNoMatchViewSpec extends ViewSpecBase {
     "have a link" in {
       val link = view.getElementsByClass("govuk-body").last().getElementsByTag("a")
 
-      link.text         must include("Re-enter your client’s Pillar 2 top-up taxes ID to try again")
+      link.text         must include("Re-enter your client’s Pillar 2 Top-up Taxes ID to try again")
       link.attr("href") must include(routes.AgentController.onPageLoadClientPillarId.url)
     }
 

--- a/test/views/agent/AgentClientPillarIdViewSpec.scala
+++ b/test/views/agent/AgentClientPillarIdViewSpec.scala
@@ -32,16 +32,16 @@ class AgentClientPillarIdViewSpec extends ViewSpecBase {
   "Agent Client PillarId View" should {
 
     "have a title" in {
-      view.getElementsByTag("title").text must include("What is your client’s Pillar 2 top-up taxes ID?")
+      view.getElementsByTag("title").text must include("What is your client’s Pillar 2 Top-up Taxes ID?")
     }
 
     "have a heading" in {
-      view.getElementsByTag("h1").text must include("What is your client’s Pillar 2 top-up taxes ID?")
+      view.getElementsByTag("h1").text must include("What is your client’s Pillar 2 Top-up Taxes ID?")
     }
 
     "have a hint" in {
       view.getElementById("value-hint").text must include(
-        "This is 15 characters, for example, XMPLR0123456789. The current filing member can find it on their Pillar 2 taxes top-up homepage."
+        "This is 15 characters, for example, XMPLR0123456789. The current filing member can find it on their Pillar 2 Top-up Taxes homepage."
       )
     }
 

--- a/test/views/agent/AgentClientUnauthorisedViewSpec.scala
+++ b/test/views/agent/AgentClientUnauthorisedViewSpec.scala
@@ -30,12 +30,12 @@ class AgentClientUnauthorisedViewSpec extends ViewSpecBase {
   "Agent Error View" should {
 
     "have a title" in {
-      val title = "You have not been authorised to report this client’s Pillar 2 top-up taxes - Report Pillar 2 top-up taxes - GOV.UK"
+      val title = "You have not been authorised to report this client’s Pillar 2 Top-up Taxes - Report Pillar 2 Top-up Taxes - GOV.UK"
       view.getElementsByTag("title").first().text mustBe title
     }
 
     "have a heading" in {
-      view.getElementsByTag("h1").text must include("You have not been authorised to report this client’s Pillar 2 top-up taxes")
+      view.getElementsByTag("h1").text must include("You have not been authorised to report this client’s Pillar 2 Top-up Taxes")
     }
 
     "have a paragraph body" in {
@@ -45,7 +45,7 @@ class AgentClientUnauthorisedViewSpec extends ViewSpecBase {
     "have a link" in {
       val link = view.getElementsByClass("govuk-body").last().getElementsByTag("a")
 
-      link.text         must include("request authorisation to report and manage this client’s Pillar 2 top-up taxes")
+      link.text         must include("request authorisation to report and manage this client’s Pillar 2 Top-up Taxes")
       link.attr("href") must include("/report-pillar2-submission-top-up-taxes/asa/home")
     }
 

--- a/test/views/agent/AgentErrorViewSpec.scala
+++ b/test/views/agent/AgentErrorViewSpec.scala
@@ -30,7 +30,7 @@ class AgentErrorViewSpec extends ViewSpecBase {
   "Agent Error View" should {
 
     "have a title" in {
-      val title = "Sorry, there is a problem with the service - Report Pillar 2 top-up taxes - GOV.UK"
+      val title = "Sorry, there is a problem with the service - Report Pillar 2 Top-up Taxes - GOV.UK"
       view.getElementsByTag("title").first().text mustBe title
     }
 

--- a/test/views/agent/AgentIndividualErrorViewSpec.scala
+++ b/test/views/agent/AgentIndividualErrorViewSpec.scala
@@ -30,7 +30,7 @@ class AgentIndividualErrorViewSpec extends ViewSpecBase {
   "Agent Individual Error View" should {
 
     "have a title" in {
-      val title = "Sorry, you’re unable to use this service - Report Pillar 2 top-up taxes - GOV.UK"
+      val title = "Sorry, you’re unable to use this service - Report Pillar 2 Top-up Taxes - GOV.UK"
       view.getElementsByTag("title").first().text mustBe title
     }
 
@@ -49,12 +49,12 @@ class AgentIndividualErrorViewSpec extends ViewSpecBase {
       val secondBullet = bulletList.first().getElementsByClass("govuk-body").get(1)
 
       firstBullet.text() must include(
-        "if you are an agent that has been given authorisation to report Pillar 2 top-up taxes on behalf of a group, you must"
+        "if you are an agent that has been given authorisation to report Pillar 2 Top-up Taxes on behalf of a group, you must"
       )
       firstBullet.getElementsByTag("a").text() must include("sign in via agent services")
       firstBullet.getElementsByTag("a").attr("href") mustBe "https://www.gov.uk/guidance/sign-in-to-your-agent-services-account"
 
-      secondBullet.text()                       must include("if you need to request authorisation to report Pillar 2 top-up taxes, you must")
+      secondBullet.text()                       must include("if you need to request authorisation to report Pillar 2 Top-up Taxes, you must")
       secondBullet.getElementsByTag("a").text() must include("request authorisation on agent services")
       secondBullet
         .getElementsByTag("a")
@@ -64,7 +64,7 @@ class AgentIndividualErrorViewSpec extends ViewSpecBase {
     "have a link" in {
       val link = view.getElementsByClass("govuk-body").last().getElementsByTag("a")
 
-      link.text         must include("Find out more about who can report for Pillar 2 top-up taxes")
+      link.text         must include("Find out more about who can report for Pillar 2 Top-up Taxes")
       link.attr("href") must include("https://www.gov.uk/guidance/report-pillar-2-top-up-taxes")
     }
 

--- a/test/views/agent/AgentOrganisationErrorViewSpec.scala
+++ b/test/views/agent/AgentOrganisationErrorViewSpec.scala
@@ -30,7 +30,7 @@ class AgentOrganisationErrorViewSpec extends ViewSpecBase {
   "Agent Organisation Error View" should {
 
     "have a title" in {
-      val title = "Sorry, you’re unable to use this service - Report Pillar 2 top-up taxes - GOV.UK"
+      val title = "Sorry, you’re unable to use this service - Report Pillar 2 Top-up Taxes - GOV.UK"
       view.getElementsByTag("title").first().text mustBe title
     }
 
@@ -49,12 +49,12 @@ class AgentOrganisationErrorViewSpec extends ViewSpecBase {
       val secondBullet = bulletList.first().getElementsByClass("govuk-body").get(1)
 
       firstBullet.text() must include(
-        "if you are an agent that has been given authorisation to report Pillar 2 top-up taxes on behalf of a group, you must"
+        "if you are an agent that has been given authorisation to report Pillar 2 Top-up Taxes on behalf of a group, you must"
       )
       firstBullet.getElementsByTag("a").text() must include("sign in via agent services")
       firstBullet.getElementsByTag("a").attr("href") mustBe "https://www.gov.uk/guidance/sign-in-to-your-agent-services-account"
 
-      secondBullet.text()                       must include("if you need to request authorisation to report Pillar 2 top-up taxes, you must")
+      secondBullet.text()                       must include("if you need to request authorisation to report Pillar 2 Top-up Taxes, you must")
       secondBullet.getElementsByTag("a").text() must include("request authorisation on agent services")
       secondBullet
         .getElementsByTag("a")
@@ -64,7 +64,7 @@ class AgentOrganisationErrorViewSpec extends ViewSpecBase {
     "have a link" in {
       val link = view.getElementsByClass("govuk-body").last().getElementsByTag("a")
 
-      link.text         must include("Find out more about who can report for Pillar 2 top-up taxes")
+      link.text         must include("Find out more about who can report for Pillar 2 Top-up Taxes")
       link.attr("href") must include("https://www.gov.uk/guidance/report-pillar-2-top-up-taxes")
     }
 

--- a/test/views/btn/BTNBeforeStartViewSpec.scala
+++ b/test/views/btn/BTNBeforeStartViewSpec.scala
@@ -30,11 +30,11 @@ class BTNBeforeStartViewSpec extends ViewSpecBase {
   "BTNBeforeStartView" should {
 
     "have a title" in {
-      view.getElementsByTag("title").text must include("Below Threshold Notification")
+      view.getElementsByTag("title").text must include("Below-Threshold Notification")
     }
 
     "have a h1 heading" in {
-      view.getElementsByTag("h1").text must include("Below Threshold Notification")
+      view.getElementsByTag("h1").text must include("Below-Threshold Notification")
     }
 
     "have two h2 headings" in {

--- a/test/views/btn/CheckYourAnswersViewSpec.scala
+++ b/test/views/btn/CheckYourAnswersViewSpec.scala
@@ -29,7 +29,7 @@ class CheckYourAnswersViewSpec extends ViewSpecBase {
   "CheckYourAnswersView" must {
 
     "have a title" in {
-      view.getElementsByTag("title").get(0).text mustEqual "Check Your Answers - Report Pillar 2 top-up taxes - GOV.UK"
+      view.getElementsByTag("title").get(0).text mustEqual "Check Your Answers - Report Pillar 2 Top-up Taxes - GOV.UK"
     }
 
     "have a H1 heading" in {
@@ -37,7 +37,7 @@ class CheckYourAnswersViewSpec extends ViewSpecBase {
     }
 
     "have a paragraph with a H2 heading" in {
-      view.getElementsByTag("h3").get(0).text mustEqual "Now submit your Below Threshold Notification"
+      view.getElementsByTag("h3").get(0).text mustEqual "Now submit your Below-Threshold Notification"
       view.getElementsByClass("govuk-body").get(0).text mustEqual
         "By submitting these details, you are confirming that the information is correct and complete to the best of your knowledge."
     }

--- a/test/views/dueandoverduereturns/DueAndOverdueReturnsViewSpec.scala
+++ b/test/views/dueandoverduereturns/DueAndOverdueReturnsViewSpec.scala
@@ -30,7 +30,7 @@ class DueAndOverdueReturnsViewSpec extends ViewSpecBase with DueAndOverdueReturn
   val dateFormatter: DateTimeFormatter        = DateTimeFormatter.ofPattern("d MMMM yyyy")
 
   def verifyCommonPageElements(view: Document): Unit = {
-    view.getElementsByTag("title").get(0).text mustEqual "Due and overdue returns - Report Pillar 2 top-up taxes - GOV.UK"
+    view.getElementsByTag("title").get(0).text mustEqual "Due and overdue returns - Report Pillar 2 Top-up Taxes - GOV.UK"
     view.getElementsByTag("h1").get(0).text mustEqual "Due and overdue returns"
 
     val headings = view.getElementsByTag("h2")

--- a/test/views/submissionhistory/SubmissionHistoryNoSubmissionsViewSpec.scala
+++ b/test/views/submissionhistory/SubmissionHistoryNoSubmissionsViewSpec.scala
@@ -31,7 +31,7 @@ class SubmissionHistoryNoSubmissionsViewSpec extends ViewSpecBase {
   "Submisison History with no submission organisation view" should {
 
     "have a title" in {
-      val title = "Submission history - Report Pillar 2 top-up taxes - GOV.UK"
+      val title = "Submission history - Report Pillar 2 Top-up Taxes - GOV.UK"
       organisationView.getElementsByTag("title").text must include(title)
     }
 

--- a/test/views/submissionhistory/SubmissionHistoryViewSpec.scala
+++ b/test/views/submissionhistory/SubmissionHistoryViewSpec.scala
@@ -37,7 +37,7 @@ class SubmissionHistoryViewSpec extends ViewSpecBase with SubmissionHistoryDataF
   "Submisison History Organisation View" should {
 
     "have a title" in {
-      val title = "Submission history - Report Pillar 2 top-up taxes - GOV.UK"
+      val title = "Submission history - Report Pillar 2 Top-up Taxes - GOV.UK"
       organisationView.getElementsByTag("title").text must include(title)
     }
 

--- a/test/views/uktr/UKTaxReturnStartViewSpec.scala
+++ b/test/views/uktr/UKTaxReturnStartViewSpec.scala
@@ -37,7 +37,7 @@ class UKTaxReturnStartViewSpec extends ViewSpecBase {
     "not have a notification banner" in {
       view.getElementsByClass("govuk-notification-banner__title").text() mustNot include("Important")
       view.getElementsByClass("govuk-notification-banner__heading").text() mustNot include(
-        "Your account has a Below Threshold Notification (BTN) and is inactive. " +
+        "Your account has a Below-Threshold Notification (BTN) and is inactive. " +
           "Submit a UK tax return (UKTR) to re-activate your account."
       )
     }
@@ -48,7 +48,7 @@ class UKTaxReturnStartViewSpec extends ViewSpecBase {
 
     "have paragraphs" in {
       view.getElementsByClass("govuk-body").get(0).text must include(
-        "A UKTR fulfills your obligation to submit Pillar 2 top-up taxes for your current accounting period. " +
+        "A UKTR fulfills your obligation to submit Pillar 2 Top-up Taxes for your current accounting period. " +
           "You can report both Domestic Top-up Tax and Multinational Top-up Tax liabilities."
       )
 
@@ -101,7 +101,7 @@ class UKTaxReturnStartViewSpec extends ViewSpecBase {
     "have a notification banner" in {
       view.getElementsByClass("govuk-notification-banner__title").text() must include("Important")
       view.getElementsByClass("govuk-notification-banner__heading").text() must include(
-        "Your account has a Below Threshold Notification (BTN) and is inactive. " +
+        "Your account has a Below-Threshold Notification (BTN) and is inactive. " +
           "Submit a UK tax return (UKTR) to re-activate your account."
       )
     }
@@ -112,7 +112,7 @@ class UKTaxReturnStartViewSpec extends ViewSpecBase {
 
     "have paragraphs" in {
       view.getElementsByClass("govuk-body").get(0).text must include(
-        "A UKTR fulfills your obligation to submit Pillar 2 top-up taxes for your current accounting period. " +
+        "A UKTR fulfills your obligation to submit Pillar 2 Top-up Taxes for your current accounting period. " +
           "You can report both Domestic Top-up Tax and Multinational Top-up Tax liabilities."
       )
 


### PR DESCRIPTION
This PR introduces several updates to the naming conventions in the Pillar 2 submission frontend. The following terms have been renamed for consistency and clarity:

Pillar 2 Top-up Tax and its variations (Pillar 2 top-up taxes, Pillar 2 top up taxes, pillar 2 top up, pillar 2 tax) have been standardized to **Pillar 2 Top-up Taxes**.
Multinational Top up Tax is now **Multinational Top-up Tax**.
Domestic Top up Tax is now **Domestic Top-up Tax**.
Below Threshold Notification is now **Below-Threshold Notification**.
Ultimate Parent is now **Ultimate Parent Entity**.
These changes ensure consistency in terminology throughout the platform.
