### PR TITLE
PIL-1721: Content Update for BTN start page

### DIFF
--- a/app/views/btn/BTNBeforeStartView.scala.html
+++ b/app/views/btn/BTNBeforeStartView.scala.html
@@ -24,6 +24,7 @@
         p: ParagraphBody,
         heading: Heading,
         bulletList: BulletList,
+        govukInsetText: GovukInsetText
 )
 
 @(mode: Mode)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
@@ -41,15 +42,17 @@
         Html(messages("btn.beforeStart.li2")),
     ), additionalListClasses = Some("govuk-list govuk-list--bullet"), itemClasses=Some("govuk-!-margin-bottom-3"))
 
+    @govukInsetText(InsetText(content = Text(messages("btn.beforeStart.insetText"))))
+
     @h2(messages("btn.beforeStart.header3"), size = "m")
     @p(messages("btn.beforeStart.p3"))
 
     @bulletList(items = List(
         Html(messages("btn.beforeStart.li3")),
-        Html(messages("btn.beforeStart.li4")),
-        Html(messages("btn.beforeStart.li5")),
-        Html(messages("btn.beforeStart.li6")),
+        Html(messages("btn.beforeStart.li4"))
     ), additionalListClasses = Some("govuk-list govuk-list--bullet"), itemClasses=Some("govuk-!-margin-bottom-3"))
+
+    @p(messages("btn.beforeStart.p4"))
 
     @govukButton(
         ButtonViewModel(messages("site.continue")).asLink(controllers.btn.routes.BTNAccountingPeriodController.onPageLoad(mode).url)

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -175,7 +175,7 @@ btn.beforeStart.header3 = Before you start
 btn.beforeStart.p3 = To submit a Below-Threshold Notification you will need to tell us:
 btn.beforeStart.li3 = the start and end date of the group’s accounting period
 btn.beforeStart.li4 = whether the group has entities located in the UK
-btn.beforeStart.p4 = If you submit a Below-Threshold Notification for a previous accounting period, any return you have submitted this accounting period will be removed.
+btn.beforeStart.p4 = If you submit a Below-Threshold Notification, this will replace any returns you’ve submitted for that period. It will also replace any returns you have already submitted for your most recent account periods.
 
 btn.accountingPeriod.title = Submit a Below-Threshold Notification for your group’s current accounting period
 btn.accountingPeriod.header = Submit a Below-Threshold Notification for your group’s current accounting period

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -163,19 +163,19 @@ uktr.ukTaxReturnStart.inactive.p1 = Your account has a Below-Threshold Notificat
 #
 ###############################################
 
-btn.beforeStart.title = Below-Threshold Notification
-btn.beforeStart.header = Below-Threshold Notification
-btn.beforeStart.p1 = A Below-Threshold Notification removes your group’s obligation to submit a UKTR for the current accounting period and all future ones.
+btn.beforeStart.title = Below-Threshold Notification (BTN)
+btn.beforeStart.header = Below-Threshold Notification (BTN)
+btn.beforeStart.p1 = A Below-Threshold Notification (BTN) removes your group’s obligation to submit a UKTR for the current and future accounting periods. HMRC will not expect to receive an information return while your group is below-threshold.
 btn.beforeStart.header2 = Who can submit a Below-Threshold Notification
 btn.beforeStart.p2 = You can submit a Below-Threshold Notification if the group:
 btn.beforeStart.li1 = does not have consolidated annual revenues of €750 million or more in at least 2 of the previous 4 accounting periods
 btn.beforeStart.li2 = is not expected to make consolidated annual revenues of €750 million or more within the next 2 accounting periods
+btn.beforeStart.insetText = If you need to submit a UK tax return for this accounting period you do not qualify for a Below-Threshold Notification.
 btn.beforeStart.header3 = Before you start
 btn.beforeStart.p3 = To submit a Below-Threshold Notification you will need to tell us:
 btn.beforeStart.li3 = the start and end date of the group’s accounting period
 btn.beforeStart.li4 = whether the group has entities located in the UK
-btn.beforeStart.li5 = whether the group’s consolidated annual revenues have been €750 million or more in at least 2 of the previous 4 accounting periods
-btn.beforeStart.li6 = whether the group is expected to make consolidated annual revenues of €750 million or more within the next 2 accounting periods
+btn.beforeStart.p4 = If you submit a Below-Threshold Notification for a previous accounting period, any return you have submitted this accounting period will be removed.
 
 btn.accountingPeriod.title = Submit a Below-Threshold Notification for your group’s current accounting period
 btn.accountingPeriod.header = Submit a Below-Threshold Notification for your group’s current accounting period

--- a/test/views/btn/BTNBeforeStartViewSpec.scala
+++ b/test/views/btn/BTNBeforeStartViewSpec.scala
@@ -30,11 +30,11 @@ class BTNBeforeStartViewSpec extends ViewSpecBase {
   "BTNBeforeStartView" should {
 
     "have a title" in {
-      view.getElementsByTag("title").text must include("Below-Threshold Notification")
+      view.getElementsByTag("title").text must include("Below-Threshold Notification (BTN)")
     }
 
     "have a h1 heading" in {
-      view.getElementsByTag("h1").text must include("Below-Threshold Notification")
+      view.getElementsByTag("h1").text must include("Below-Threshold Notification (BTN)")
     }
 
     "have two h2 headings" in {
@@ -44,7 +44,7 @@ class BTNBeforeStartViewSpec extends ViewSpecBase {
 
     "have following contents" in {
       view.getElementsByClass("govuk-body").text must include(
-        "A Below-Threshold Notification removes your group’s obligation to submit a UKTR for the current accounting period and all future ones."
+        "A Below-Threshold Notification (BTN) removes your group’s obligation to submit a UKTR for the current and future accounting periods. HMRC will not expect to receive an information return while your group is below-threshold."
       )
 
       view.getElementsByClass("govuk-body").text must include(
@@ -61,11 +61,12 @@ class BTNBeforeStartViewSpec extends ViewSpecBase {
         "is not expected to make consolidated annual revenues of €750 million or more within the next 2 accounting periods"
       )
       view.getElementsByTag("li").text must include("the start and end date of the group’s accounting period")
-      view.getElementsByTag("li").text must include(
-        "whether the group’s consolidated annual revenues have been €750 million or more in at least 2 of the previous 4 accounting periods"
+      view.getElementsByTag("li").text must include("whether the group has entities located in the UK")
+      view.getElementsByClass("govuk-body").text must include(
+        "If you submit a Below-Threshold Notification for a previous accounting period, any return you have submitted this accounting period will be removed."
       )
-      view.getElementsByTag("li").text must include(
-        "whether the group is expected to make consolidated annual revenues of €750 million or more within the next 2 accounting periods "
+      view.getElementsByClass("govuk-inset-text").text must include(
+        "If you need to submit a UK tax return for this accounting period you do not qualify for a Below-Threshold Notification."
       )
     }
 

--- a/test/views/btn/BTNBeforeStartViewSpec.scala
+++ b/test/views/btn/BTNBeforeStartViewSpec.scala
@@ -63,7 +63,7 @@ class BTNBeforeStartViewSpec extends ViewSpecBase {
       view.getElementsByTag("li").text must include("the start and end date of the group’s accounting period")
       view.getElementsByTag("li").text must include("whether the group has entities located in the UK")
       view.getElementsByClass("govuk-body").text must include(
-        "If you submit a Below-Threshold Notification for a previous accounting period, any return you have submitted this accounting period will be removed."
+        "If you submit a Below-Threshold Notification, this will replace any returns you’ve submitted for that period. It will also replace any returns you have already submitted for your most recent account periods."
       )
       view.getElementsByClass("govuk-inset-text").text must include(
         "If you need to submit a UK tax return for this accounting period you do not qualify for a Below-Threshold Notification."


### PR DESCRIPTION
1. The page should be accessible via url:/below-threshold-notification/start
2. Additional information clarifies that an information return (IR) is not needed when BTN is submitted"HMRC will not expect to receive an information return while your group is below- threshold"
3. Include content to H2: "If you need to submit a UK tax return for this accounting period, you do not qualify for a Below-Threshold Notification.
4. Remove the 3&4 eligibility criteria under H3
5. The last paragraph should include "If you submit a Below-Threshold Notification, this will replace any returns you've submitted for that period. It will also replace any returns you have already submitted for your most recent account period."
6. The page should display ALL the current content, including the various sections, such as H1, H2 and H3, as shown in the TO-BE prototype
7. The"Back" button should allow the user to return to the previous step/Page.
8. The "Green Continue" button should be functional for users to navigate to the next page