### PR TITLE
PIL - 1822 : Submission history with Amendment

### DIFF
--- a/app/models/obligationsandsubmissions/Submission.scala
+++ b/app/models/obligationsandsubmissions/Submission.scala
@@ -38,13 +38,13 @@ object SubmissionType extends Enum[SubmissionType] with PlayJsonEnum[SubmissionT
     override val fullName: String = "UK Tax Return"
   }
   case object UKTR_AMEND extends SubmissionType {
-    override val fullName: String = "UK Tax Return Amend"
+    override val fullName: String = "UK Tax Return amendment"
   }
   case object ORN_CREATE extends SubmissionType {
-    override val fullName: String = "Overseas Return Notification Create"
+    override val fullName: String = "Overseas Return Notification"
   }
   case object ORN_AMEND extends SubmissionType {
-    override val fullName: String = "Overseas Return Notification Amend"
+    override val fullName: String = "Overseas Return Notification amendment"
   }
   case object BTN extends SubmissionType {
     override val fullName: String = "Below-Threshold Notification"

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -250,8 +250,8 @@ submissionHistory.heading = Submission history
 submissionHistory.group.p1 = You can find all submissions and amendments made by your group during this accounting period and the previous 6 accounting periods.
 submissionHistory.group.p2 = Where you’ve made changes to a tax return or information return, we’ll list these as individual submissions.
 submissionHistory.agent.p1 = You can find all submissions and amendments made by your client during this accounting period and the previous 6 accounting periods.
-submissionHistory.agent.p2 = When your client makes changes to a tax return or information return, we’ll list these as individual submissions.
-submissionHistory.insetText = You can amend your submissions at any time, except for the UK Tax Return, which must be updated within 12 months of the submission deadline.
+submissionHistory.agent.p2 = Where your client makes changes to a tax return or information return, we’ll list these as individual submissions.
+submissionHistory.insetText = You can amend submissions at any time, except for the UK Tax Return, which must be updated within 12 months of the submission deadline.
 submissionHistory.typeOfReturn = Type of return
 submissionHistory.submissionDate = Submission date
 submissionHistory.h2 = Due and overdue returns
@@ -302,4 +302,5 @@ dueAndOverdueReturns.agent.noReturns = Your client is up to date with their retu
 dueAndOverdueReturns.agent.submissionHistory.description1 = You can find full details of your client’s submitted returns on the
 
 ###############################################
+
 

--- a/test/views/submissionhistory/SubmissionHistoryViewSpec.scala
+++ b/test/views/submissionhistory/SubmissionHistoryViewSpec.scala
@@ -57,7 +57,7 @@ class SubmissionHistoryViewSpec extends ViewSpecBase with SubmissionHistoryDataF
 
     "have a inset text" in {
       organisationView.getElementsByClass("govuk-inset-text").text must include(
-        "You can amend your submissions at any time, except for the UK Tax Return, which must be updated within 12 months of the submission deadline."
+        "You can amend submissions at any time, except for the UK Tax Return, which must be updated within 12 months of the submission deadline."
       )
     }
 
@@ -103,7 +103,7 @@ class SubmissionHistoryViewSpec extends ViewSpecBase with SubmissionHistoryDataF
         "You can find all submissions and amendments made by your client during this accounting period and the previous 6 accounting periods."
       )
       paragraph.get(2).text must include(
-        "When your client makes changes to a tax return or information return, we’ll list these as individual submissions."
+        "Where your client makes changes to a tax return or information return, we’ll list these as individual submissions."
       )
     }
 


### PR DESCRIPTION
This PR includes changes to the submission type naming conventions and updates to the agent view of submission history page content as per the prototype