### PR TITLE
PIL-1980 : Update content on BTN success notification banner  page(Group's view)

### DIFF
--- a/app/views/btn/BTNConfirmationView.scala.html
+++ b/app/views/btn/BTNConfirmationView.scala.html
@@ -41,14 +41,15 @@
         attributes = Map("id" -> "plr2-banner")
     ))
 
-    @p(messages("btn.confirmation.p1", submissionDate, accountingPeriodStartDate))
+    @p(messages("btn.confirmation.group.p1", submissionDate))
+    @p(messages("btn.confirmation.p2", accountingPeriodStartDate))
 
     @printLink(messages("site.print"))
     @pdfLink(messages("site.pdf"), controllers.btn.routes.BTNConfirmationController.onDownloadConfirmation.url)
 
     @h2(messages("btn.confirmation.subheading"))
-    @p(messages("btn.confirmation.p2"))
-    @paragraphMessageWithLink(message1 = Some(messages("btn.confirmation.p3")), linkMessage = messages("btn.confirmation.p3.link"), linkUrl = controllers.uktr.routes.UKTaxReturnStartController.onPageLoad.url, linkFullStop = true, classes = "govuk-body hmrc-!-js-visible")
-    @paragraphMessageWithLink(linkMessage = messages("btn.confirmation.p4.link"), linkUrl = appConfig.pillar2FrontendUrl, classes = "govuk-body govuk-!-display-none-print")
+    @p(messages("btn.confirmation.group.p3"))
+    @p(messages("btn.confirmation.group.p4"))
 
+    @paragraphMessageWithLink(linkMessage = messages("btn.confirmation.p5.group.link"), linkUrl = appConfig.pillar2FrontendUrl, classes = "govuk-body govuk-!-display-none-print")
 }

--- a/app/views/pdf/BTNConfirmationPdf.scala.xml
+++ b/app/views/pdf/BTNConfirmationPdf.scala.xml
@@ -59,14 +59,16 @@
                 </fo:block-container>
 
                 <!-- First paragraph -->
-                <fo:block id="more-info-date" margin-bottom="5mm">@messages("btn.confirmation.p1", currentDate, startDate)</fo:block>
+                <fo:block id="more-info-current-date" margin-bottom="5mm">@messages("btn.confirmation.group.p1", currentDate)</fo:block>
+                <!-- Second paragraph -->
+                <fo:block id="more-info-start-date" margin-bottom="5mm">@messages("btn.confirmation.p2", startDate)</fo:block>
                 <!-- What happens next -->
                 <fo:block role="H2"  id="what-happens-next" font-size="14pt" font-weight="bold" margin-bottom="5mm">@messages("btn.confirmation.subheading")</fo:block>
 
-                <!-- Second paragraph -->
-                <fo:block id="removed-group-info" margin-bottom="5mm">@messages("btn.confirmation.p2")</fo:block>
                 <!-- Third paragraph -->
-                <fo:block id="submit-additional-info" margin-bottom="5mm">@messages("btn.confirmation.p3") @messages("btn.confirmation.p3.link").</fo:block>
+                <fo:block id="removed-group-info" margin-bottom="5mm">@messages("btn.confirmation.group.p3")</fo:block>
+                <!-- Fourth paragraph -->
+                <fo:block id="submit-additional-info" margin-bottom="5mm">@messages("btn.confirmation.group.p4")</fo:block>
 
             </fo:block-container>
         </fo:flow>

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -222,12 +222,12 @@ btn.cya.p2 = By submitting these details, you are confirming that the informatio
 
 btn.confirmation.title = Below-Threshold Notification successful
 btn.confirmation.heading = Below-Threshold Notification successful
-btn.confirmation.p1 = You have submitted a Below-Threshold Notification on {0}. This will be effective from {1}.
+btn.confirmation.group.p1 = You have submitted a Below-Threshold Notification on {0}.
+btn.confirmation.p2 = This is effective from the start of the accounting period you selected, {0}.
 btn.confirmation.subheading = What happens next
-btn.confirmation.p2 = HMRC has removed your group’s obligation to submit a UK Tax Return for this current accounting period and any future ones.
-btn.confirmation.p3 = If your group becomes liable for a UK Tax Return in the future, you must let HMRC know by submitting a UK Tax Return to remove the Below-Threshold Notification from your account. You can
-btn.confirmation.p3.link = find out more about submitting a UKTR
-btn.confirmation.p4.link = View account homepage
+btn.confirmation.group.p3 = This Below-Threshold Notification satisfies your group’s obligation to submit a UKTR for the current and future accounting periods. HMRC will not expect to receive an information return while your group remains below-threshold.
+btn.confirmation.group.p4 = You must submit a UK Tax Return if your group meets the threshold conditions in the future.
+btn.confirmation.p5.group.link = Back to group’s homepage
 
 btn.error.title = Sorry, there is a problem with the service
 btn.error.heading = Sorry, there is a problem with the service

--- a/test/views/btn/BTNConfirmationViewSpec.scala
+++ b/test/views/btn/BTNConfirmationViewSpec.scala
@@ -47,29 +47,29 @@ class BTNConfirmationViewSpec extends ViewSpecBase {
       view.getElementsByTag("h2").text() must include("What happens next")
     }
 
-    "have paragraph content" in {
+    "in an organisation flow have paragraph content" in {
       view.getElementsByClass("govuk-body").text must include(
-        s"You have submitted a Below-Threshold Notification on $currentDate. This will be effective from $startDate."
+        s"You have submitted a Below-Threshold Notification on $currentDate."
       )
 
       view.getElementsByClass("govuk-body").text must include(
-        "HMRC has removed your group’s obligation to submit a UK Tax Return for this current accounting period and any future ones."
+        s"This is effective from the start of the accounting period you selected, $startDate."
       )
 
       view.getElementsByClass("govuk-body").text must include(
-        "If your group becomes liable for a UK Tax Return in the future, you must let HMRC know by submitting a UK Tax Return to remove the Below-Threshold Notification from your account."
+        "This Below-Threshold Notification satisfies your group’s obligation to submit a UKTR for the current and future accounting periods. HMRC will not expect to receive an information return while your group remains below-threshold."
+      )
+
+      view.getElementsByClass("govuk-body").text must include(
+        "You must submit a UK Tax Return if your group meets the threshold conditions in the future."
       )
     }
 
     "have links" in {
-      val linkOne = view.getElementsByClass("govuk-body").get(2).getElementsByTag("a")
-      val linkTwo = view.getElementsByClass("govuk-body").get(3).getElementsByTag("a")
+      val linkOne = view.getElementsByClass("govuk-body").get(4).getElementsByTag("a")
 
-      linkOne.text         must include("find out more about submitting a UKTR")
-      linkOne.attr("href") must include("/uk-tax-return")
-
-      linkTwo.text()       must include("View account homepage")
-      linkTwo.attr("href") must include("/report-pillar2-top-up-taxes")
+      linkOne.text()       must include("Back to group’s homepage")
+      linkOne.attr("href") must include("/report-pillar2-top-up-taxes")
     }
   }
 }


### PR DESCRIPTION
BTN Confirmation view and pdf confirmation content updated to reflect latest prototype for organisation flow.

**BTN Confirmation view**
<img width="1152" alt="Screenshot 2025-05-02 at 16 33 55" src="https://github.com/user-attachments/assets/38abd857-b7e7-4294-a630-3252c3eeae38" />

**BTN pdf Confirmation view**
<img width="1284" alt="Screenshot 2025-05-07 at 10 34 25" src="https://github.com/user-attachments/assets/83a25705-bd70-4e2b-9add-cfa28fea29a8" />

