### PR TITLE
PIL-2057 Update obligations submissions array to be optional 

### DIFF
--- a/app/controllers/btn/BTNAccountingPeriodController.scala
+++ b/app/controllers/btn/BTNAccountingPeriodController.scala
@@ -91,7 +91,7 @@ class BTNAccountingPeriodController @Inject() (
 
         accountingPeriodDetails
           .map {
-            case period if !accountStatus && period.obligations.exists(_.submissions.exists(_.submissionType == BTN)) =>
+            case period if !accountStatus && period.obligations.exists(_.submissions.exists(_.exists(_.submissionType == BTN))) =>
               Ok(btnAlreadyInPlaceView())
             case period if !accountStatus && period.obligations.exists(_.status == ObligationStatus.Fulfilled) =>
               Ok(

--- a/app/models/obligationsandsubmissions/Obligation.scala
+++ b/app/models/obligationsandsubmissions/Obligation.scala
@@ -19,7 +19,7 @@ package models.obligationsandsubmissions
 import enumeratum.{Enum, EnumEntry, PlayJsonEnum}
 import play.api.libs.json._
 
-case class Obligation(obligationType: ObligationType, status: ObligationStatus, canAmend: Boolean, submissions: Seq[Submission])
+case class Obligation(obligationType: ObligationType, status: ObligationStatus, canAmend: Boolean, submissions: Option[Seq[Submission]])
 
 object Obligation {
   implicit val format: OFormat[Obligation] = Json.format[Obligation]

--- a/app/views/helpers/SubmissionHistoryHelper.scala
+++ b/app/views/helpers/SubmissionHistoryHelper.scala
@@ -32,7 +32,10 @@ object SubmissionHistoryHelper {
     accountingPeriods
       .filter(accountPeriod => accountPeriod.obligations.flatMap(_.submissions).nonEmpty)
       .map { periodsWithSubmissions =>
-        val rows = periodsWithSubmissions.obligations.flatMap(_.submissions).map(createTableRows)
+        val rows = periodsWithSubmissions.obligations
+          .flatMap(_.submissions.getOrElse(Seq.empty))
+          .map(createTableRows)
+
         createTable(periodsWithSubmissions.startDate, periodsWithSubmissions.endDate, rows)
       }
 

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -100,7 +100,7 @@ trait SpecBase
             obligationType = ObligationType.UKTR,
             status = status,
             canAmend = false,
-            submissions = Seq.empty
+            submissions = None
           )
         )
       )
@@ -120,7 +120,7 @@ trait SpecBase
             obligationType = ObligationType.UKTR,
             status = Open,
             canAmend = false,
-            submissions = Seq.empty
+            submissions = None
           )
         )
       ),
@@ -134,7 +134,7 @@ trait SpecBase
             obligationType = ObligationType.UKTR,
             status = Open,
             canAmend = false,
-            submissions = Seq.empty
+            submissions = None
           )
         )
       )

--- a/test/controllers/FilteredAccountingPeriodDetailsSpec.scala
+++ b/test/controllers/FilteredAccountingPeriodDetailsSpec.scala
@@ -30,7 +30,7 @@ class FilteredAccountingPeriodDetailsSpec extends AnyFreeSpec with Matchers {
   private def minusYears(amountOfYears: Int) = LocalDate.now.minusYears(amountOfYears)
   private def plusYears(amountOfYears: Int)  = LocalDate.now.plusYears(amountOfYears)
 
-  private val obligationData: Seq[Obligation] = Seq(Obligation(UKTR, Open, canAmend = false, Seq.empty))
+  private val obligationData: Seq[Obligation] = Seq(Obligation(UKTR, Open, canAmend = false, None))
 
   private val unfilteredList: Seq[AccountingPeriodDetails] = Seq(
     AccountingPeriodDetails(minusYears(1), now, plusYears(1), underEnquiry = false, obligationData),

--- a/test/controllers/btn/BTNAccountingPeriodControllerSpec.scala
+++ b/test/controllers/btn/BTNAccountingPeriodControllerSpec.scala
@@ -54,7 +54,7 @@ class BTNAccountingPeriodControllerSpec extends SpecBase {
   val dates: AccountingPeriod = AccountingPeriod(LocalDate.now, LocalDate.now.plusYears(1))
   val dateHelper = new ViewHelpers()
 
-  val obligationData: Seq[Obligation] = Seq(Obligation(UKTR, Open, canAmend = false, Seq.empty))
+  val obligationData: Seq[Obligation] = Seq(Obligation(UKTR, Open, canAmend = false, None))
   val chosenAccountPeriod: AccountingPeriodDetails = AccountingPeriodDetails(
     LocalDate.now.minusYears(2),
     LocalDate.now.minusYears(1),
@@ -253,7 +253,7 @@ class BTNAccountingPeriodControllerSpec extends SpecBase {
         LocalDate.now(),
         LocalDate.now().plusYears(1),
         underEnquiry = false,
-        Seq(Obligation(UKTR, Fulfilled, canAmend = true, Seq(Submission(UKTR_CREATE, ZonedDateTime.now(), None))))
+        Seq(Obligation(UKTR, Fulfilled, canAmend = true, Some(Seq(Submission(UKTR_CREATE, ZonedDateTime.now(), None)))))
       )
 
       when(mockSubscriptionConnector.getSubscriptionCache(any())(any[HeaderCarrier], any[ExecutionContext]))

--- a/test/controllers/btn/BTNChooseAccountingPeriodControllerSpec.scala
+++ b/test/controllers/btn/BTNChooseAccountingPeriodControllerSpec.scala
@@ -47,7 +47,7 @@ class BTNChooseAccountingPeriodControllerSpec extends SpecBase {
 
   val plrReference     = "testPlrRef"
   val organisationName = "orgName"
-  val obligationData: Seq[Obligation] = Seq(Obligation(UKTR, Open, canAmend = false, Seq.empty))
+  val obligationData: Seq[Obligation] = Seq(Obligation(UKTR, Open, canAmend = false, None))
 
   val obligationsAndSubmissionsSuccess: ObligationsAndSubmissionsSuccess =
     ObligationsAndSubmissionsSuccess(

--- a/test/controllers/helpers/SubmissionHistoryDataFixture.scala
+++ b/test/controllers/helpers/SubmissionHistoryDataFixture.scala
@@ -38,16 +38,18 @@ trait SubmissionHistoryDataFixture {
             UKTR,
             Fulfilled,
             canAmend = true,
-            Seq(
-              Submission(
-                UKTR_CREATE,
-                ZonedDateTime.now,
-                None
-              ),
-              Submission(
-                UKTR_CREATE,
-                ZonedDateTime.now,
-                None
+            Some(
+              Seq(
+                Submission(
+                  UKTR_CREATE,
+                  ZonedDateTime.now,
+                  None
+                ),
+                Submission(
+                  UKTR_CREATE,
+                  ZonedDateTime.now,
+                  None
+                )
               )
             )
           )
@@ -63,11 +65,13 @@ trait SubmissionHistoryDataFixture {
             UKTR,
             Fulfilled,
             canAmend = true,
-            Seq(
-              Submission(
-                UKTR_CREATE,
-                ZonedDateTime.now,
-                None
+            Some(
+              Seq(
+                Submission(
+                  UKTR_CREATE,
+                  ZonedDateTime.now,
+                  None
+                )
               )
             )
           )

--- a/test/helpers/DueAndOverdueReturnsDataFixture.scala
+++ b/test/helpers/DueAndOverdueReturnsDataFixture.scala
@@ -41,7 +41,7 @@ trait DueAndOverdueReturnsDataFixture {
       obligationType = obligationType,
       status = status,
       canAmend = canAmend,
-      submissions = Seq.empty
+      submissions = None
     )
 
   def createAccountingPeriod(

--- a/test/helpers/TestDataFixture.scala
+++ b/test/helpers/TestDataFixture.scala
@@ -74,8 +74,10 @@ trait TestDataFixture extends SubscriptionLocalDataFixture {
                 obligationType = obligationType,
                 status = status,
                 canAmend = canAmend,
-                submissions = Seq(
-                  Submission(submissionType = submissionType, receivedDate = receivedDate, country = country)
+                submissions = Some(
+                  Seq(
+                    Submission(submissionType = submissionType, receivedDate = receivedDate, country = country)
+                  )
                 )
               )
             )

--- a/test/views/btn/BTNReturnSubmittedViewSpec.scala
+++ b/test/views/btn/BTNReturnSubmittedViewSpec.scala
@@ -53,7 +53,7 @@ class BTNReturnSubmittedViewSpec extends ViewSpecBase {
     accountingPeriodEndDate,
     LocalDate.now().plusYears(1),
     underEnquiry = false,
-    Seq(Obligation(UKTR, Fulfilled, canAmend = true, Seq(Submission(UKTR_CREATE, ZonedDateTime.now(), None))))
+    Seq(Obligation(UKTR, Fulfilled, canAmend = true, Some(Seq(Submission(UKTR_CREATE, ZonedDateTime.now(), None)))))
   )
 
   val formattedStartDate: String = accountingPeriodStartDate.format(DateTimeFormatter.ofPattern("d MMMM yyyy"))

--- a/test/views/helpers/SubmissionHistoryHelperSpec.scala
+++ b/test/views/helpers/SubmissionHistoryHelperSpec.scala
@@ -43,9 +43,9 @@ class SubmissionHistoryHelperSpec extends AnyWordSpec with Matchers with Mockito
       val submission1 = Submission(SubmissionType.UKTR_CREATE, ZonedDateTime.now, None)
       val submission2 = Submission(SubmissionType.GIR, ZonedDateTime.now, None)
 
-      val obligation1 = Obligation(ObligationType.UKTR, Open, canAmend = true, Seq(submission1, submission2))
-      val obligation2 = Obligation(ObligationType.GIR, Fulfilled, canAmend = false, Seq(submission1))
-      val obligation3 = Obligation(ObligationType.UKTR, Open, canAmend = true, Seq.empty)
+      val obligation1 = Obligation(ObligationType.UKTR, Open, canAmend = true, Some(Seq(submission1, submission2)))
+      val obligation2 = Obligation(ObligationType.GIR, Fulfilled, canAmend = false, Some(Seq(submission1)))
+      val obligation3 = Obligation(ObligationType.UKTR, Open, canAmend = true, None)
 
       val accountingPeriods = Seq(
         AccountingPeriodDetails(startDate1, endDate1, LocalDate.now, underEnquiry = false, Seq(obligation1)),


### PR DESCRIPTION
Update the `submissions` sequence to be optional throughout the codebase.