### PR TITLE
PIL-1827 - update submission history and due and overdue returns to call subscription service

### DIFF
--- a/app/controllers/dueandoverduereturns/DueAndOverdueReturnsController.scala
+++ b/app/controllers/dueandoverduereturns/DueAndOverdueReturnsController.scala
@@ -16,13 +16,17 @@
 
 package controllers.dueandoverduereturns
 
+import cats.data.OptionT
 import config.FrontendAppConfig
 import controllers.actions._
 import controllers.routes.JourneyRecoveryController
-import models.requests.SubscriptionDataRequest
+import models.UserAnswers
+import pages.PlrReferencePage
 import play.api.Logging
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import repositories.SessionRepository
+import services.SubscriptionService
 import services.obligationsandsubmissions.ObligationsAndSubmissionsService
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
@@ -31,16 +35,18 @@ import utils.Constants.SUBMISSION_ACCOUNTING_PERIODS
 import views.html.dueandoverduereturns.DueAndOverdueReturnsView
 
 import java.time.LocalDate
-import javax.inject.{Inject, Named}
-import scala.concurrent.ExecutionContext
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
 
 class DueAndOverdueReturnsController @Inject() (
-  val controllerComponents:               MessagesControllerComponents,
-  getSubscriptionData:                    SubscriptionDataRetrievalAction,
-  requireSubscriptionData:                SubscriptionDataRequiredAction,
-  obligationsAndSubmissionsService:       ObligationsAndSubmissionsService,
-  view:                                   DueAndOverdueReturnsView,
-  @Named("EnrolmentIdentifier") identify: IdentifierAction
+  val controllerComponents:         MessagesControllerComponents,
+  getData:                          DataRetrievalAction,
+  requireData:                      DataRequiredAction,
+  obligationsAndSubmissionsService: ObligationsAndSubmissionsService,
+  view:                             DueAndOverdueReturnsView,
+  subscriptionService:              SubscriptionService,
+  sessionRepository:                SessionRepository,
+  identify:                         IdentifierAction
 )(implicit
   appConfig: FrontendAppConfig,
   ec:        ExecutionContext
@@ -49,18 +55,20 @@ class DueAndOverdueReturnsController @Inject() (
     with Logging {
 
   def onPageLoad(): Action[AnyContent] =
-    (identify andThen getSubscriptionData andThen requireSubscriptionData).async { implicit request: SubscriptionDataRequest[AnyContent] =>
+    (identify andThen getData andThen requireData).async { implicit request =>
       implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequestAndSession(request, request.session)
-
-      val fromDate  = LocalDate.now().minusYears(SUBMISSION_ACCOUNTING_PERIODS)
-      val toDate    = LocalDate.now()
-      val pillar2Id = request.subscriptionLocalData.plrReference
-      obligationsAndSubmissionsService
-        .handleData(pillar2Id, fromDate, toDate)
-        .map { data =>
-          Ok(view(data, fromDate, toDate, request.isAgent))
-
-        }
+      (for {
+        maybeUserAnswer <- OptionT.liftF(sessionRepository.get(request.userId))
+        userAnswers = maybeUserAnswer.getOrElse(UserAnswers(request.userId))
+        maybeSubscriptionData <- OptionT.liftF(subscriptionService.getSubscriptionCache(request.userId))
+        updatedAnswers        <- OptionT.liftF(Future.fromTry(userAnswers.set(PlrReferencePage, maybeSubscriptionData.plrReference)))
+        _                     <- OptionT.liftF(sessionRepository.set(updatedAnswers))
+        fromDate  = LocalDate.now().minusYears(SUBMISSION_ACCOUNTING_PERIODS)
+        toDate    = LocalDate.now()
+        pillar2Id = updatedAnswers.get(PlrReferencePage)
+        data <- OptionT.liftF(obligationsAndSubmissionsService.handleData(pillar2Id.get, fromDate, toDate))
+      } yield Ok(view(data, fromDate, toDate, request.isAgent))).value
+        .map(_.getOrElse(Redirect(JourneyRecoveryController.onPageLoad())))
         .recover { case e =>
           logger.error(s"Error calling obligationsAndSubmissionsService.handleData: ${e.getMessage}", e)
           Redirect(JourneyRecoveryController.onPageLoad())

--- a/test/controllers/dueandoverduereturns/DueAndOverdueReturnsControllerSpec.scala
+++ b/test/controllers/dueandoverduereturns/DueAndOverdueReturnsControllerSpec.scala
@@ -28,6 +28,7 @@ import play.api.Application
 import play.api.inject.bind
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+import services.SubscriptionService
 import services.obligationsandsubmissions.ObligationsAndSubmissionsService
 import uk.gov.hmrc.http.HeaderCarrier
 import views.html.dueandoverduereturns.DueAndOverdueReturnsView
@@ -40,7 +41,8 @@ class DueAndOverdueReturnsControllerSpec extends SpecBase with MockitoSugar with
     subscriptionLocalData = Some(someSubscriptionLocalData),
     userAnswers = Some(emptyUserAnswers)
   ).overrides(
-    bind[ObligationsAndSubmissionsService].toInstance(mockObligationsAndSubmissionsService)
+    bind[ObligationsAndSubmissionsService].toInstance(mockObligationsAndSubmissionsService),
+    bind[SubscriptionService].toInstance(mockSubscriptionService)
   ).build()
 
   lazy val view: DueAndOverdueReturnsView = application.injector.instanceOf[DueAndOverdueReturnsView]
@@ -50,6 +52,8 @@ class DueAndOverdueReturnsControllerSpec extends SpecBase with MockitoSugar with
       "return OK and display the correct view for a GET with no returns" in {
         when(mockObligationsAndSubmissionsService.handleData(any(), any(), any())(any[HeaderCarrier]))
           .thenReturn(Future.successful(emptyResponse))
+        when(mockSubscriptionService.getSubscriptionCache(any())(any[HeaderCarrier]))
+          .thenReturn(Future.successful(someSubscriptionLocalData))
 
         val request = FakeRequest(GET, controllers.dueandoverduereturns.routes.DueAndOverdueReturnsController.onPageLoad.url)
         val result  = route(application, request).value
@@ -66,6 +70,8 @@ class DueAndOverdueReturnsControllerSpec extends SpecBase with MockitoSugar with
       "return OK and display the correct view for a GET with due returns" in {
         when(mockObligationsAndSubmissionsService.handleData(any(), any(), any())(any[HeaderCarrier]))
           .thenReturn(Future.successful(dueReturnsResponse))
+        when(mockSubscriptionService.getSubscriptionCache(any())(any[HeaderCarrier]))
+          .thenReturn(Future.successful(someSubscriptionLocalData))
 
         val request = FakeRequest(GET, controllers.dueandoverduereturns.routes.DueAndOverdueReturnsController.onPageLoad.url)
         val result  = route(application, request).value
@@ -82,6 +88,8 @@ class DueAndOverdueReturnsControllerSpec extends SpecBase with MockitoSugar with
       "return OK and display the correct view for a GET with overdue returns" in {
         when(mockObligationsAndSubmissionsService.handleData(any(), any(), any())(any[HeaderCarrier]))
           .thenReturn(Future.successful(overdueReturnsResponse))
+        when(mockSubscriptionService.getSubscriptionCache(any())(any[HeaderCarrier]))
+          .thenReturn(Future.successful(someSubscriptionLocalData))
 
         val request = FakeRequest(GET, controllers.dueandoverduereturns.routes.DueAndOverdueReturnsController.onPageLoad.url)
         val result  = route(application, request).value


### PR DESCRIPTION
Rather than develop a robust but longterm solution this ticket just adds the subscription call to the submission history and due and overdue in order for them to be called directly from the homepage.

This method means we we call etmp every time we go onto these pages.